### PR TITLE
Do not set invalid playlist on youtube player

### DIFF
--- a/src/js/providers/youtube/player.js
+++ b/src/js/providers/youtube/player.js
@@ -29,7 +29,7 @@ export default class Player extends BasePlayer {
 				controls      : options.hideControls ? 0 : 1,
 				iv_load_policy: 3,
 				loop          : options.loop,
-				playlist      : options.loop ? this.videoId : '',
+				playlist      : options.loop ? this.videoId : undefined,
 				rel           : 0,
 				autoplay      : false,
 				...youtube,


### PR DESCRIPTION
Tested it by overwriting it with the option `video.playerOptions.youtube.playlist: undefined` which seems to work.

Fixes: Splidejs/splide#362